### PR TITLE
Automate typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,16 @@ Some explanation on this bug.
 To reproduce this, simply clone the repo into your `.config` folder, and run :
 
 ```bash
-NVIM_APPNAME=treesitter-neovim-bug nvim +912 -c "set noswapfile" ~/.config/treesitter-neovim-bug/test.lua
+NVIM_APPNAME=treesitter-neovim-bug nvim
 ```
 
+Neovim will automatically open the file `test.lua` and start typing `ddxuj` repeatedly. Nvim will eventually crash.
+
+## before automation
+
+```bash
+NVIM_APPNAME=treesitter-neovim-bug nvim +912 -c "set noswapfile" ~/.config/treesitter-neovim-bug/test.lua
+```
 
 Once in this file, run the following vim commnds in quick succession: 
 

--- a/init.lua
+++ b/init.lua
@@ -2,3 +2,25 @@ vim.keymap.set({ "n", "v" }, "x", function()
 	local bug = require("bug")
 	bug.node_incremental(bug.get_node_at_cursor())
 end, { noremap = true, silent = true, desc = "Go window up" })
+
+vim.api.nvim_command("set noswapfile")
+
+local keys = "ddxujddxuhjddxujddxujddxujddxuj"
+local i = 100000
+local timer = vim.loop.new_timer()
+
+timer:start(100, 30, vim.schedule_wrap(function()
+	if i <= #keys then
+		local key = keys:sub(i, i)
+		vim.api.nvim_feedkeys(key, "m", false)
+		i = i + 1
+	else
+		-- Press ":e<CR>" after the sequence finishes
+		local cmd = vim.api.nvim_replace_termcodes(":e! ~/.config/treesitter-neovim-bug/test.lua<CR>:912<CR>", true,
+			false, true)
+		vim.api.nvim_feedkeys(cmd, "m", false)
+		i = 0
+		-- timer:stop()
+		-- timer:close()
+	end
+end))


### PR DESCRIPTION
I add some code to init.lua to make it type `ddxuj` automatically, and reopen the file after each cycle.